### PR TITLE
[Feat] Aiohttp Connector and Timeout Options 

### DIFF
--- a/jhsingle_native_proxy/main.py
+++ b/jhsingle_native_proxy/main.py
@@ -32,7 +32,7 @@ def patch_default_headers():
 
 def make_app(destport, prefix, command, presentation_path, authtype, request_timeout, ready_check_path, ready_timeout, repo,
                 repobranch, repofolder, conda_env_name, debug, logs, forward_user_info, query_user_info, progressive,
-                websocket_max_message_size):
+                websocket_max_message_size, aiohttp_no_ssl_connector, aiohttp_request_timeout):
 
     presentation_basename = ''
     presentation_dirname = ''
@@ -57,7 +57,7 @@ def make_app(destport, prefix, command, presentation_path, authtype, request_tim
         
         command = ['python3', '-m', 'jhsingle_native_proxy.conda_runner', conda_prefix, env_path] + command
 
-    proxy_handler = _make_serverproxy_handler('mainprocess', command, {}, False, destport, ready_check_path, ready_timeout, gitwrapper, {})
+    proxy_handler = _make_serverproxy_handler('mainprocess', command, {}, False, destport, ready_check_path, ready_timeout, gitwrapper, aiohttp_no_ssl_connector, aiohttp_request_timeout, {})
 
     options = dict(debug=debug,
     logs=logs,
@@ -169,9 +169,12 @@ def get_port_from_env():
 @click.option('--progressive/--no-progressive', default=False, help='Progressively flush responses as they arrive (good for Voila)')
 @click.option('--websocket-max-message-size', default=0, type=click.INT, help='Max size of websocket data (default 0, meaning leave to library defaults)')
 @click.argument('command', nargs=-1, required=True)
+@click.option('--aiohttp-no-ssl-connector', is_flag=True, help='Sets up pre-configured TCP connector. Include to disable SSL verification')
+@click.option('--aiohttp-request-timeout', default=300, type=click.INT, help='Timeout settings for aiohttp are stored in ClientTimeout data structure. The maximal number of seconds for the whole operation including connection establishment, request sending and response reading. Set to 0 to disable)')
+
 def run(port, destport, ip, presentation_path, debug, logs, authtype, request_timeout, last_activity_interval, force_alive, ready_check_path, 
         ready_timeout, repo, repobranch, repofolder, conda_env, allow_root, notebookapp_allow_origin, forward_user_info, query_user_info, progressive, 
-        websocket_max_message_size, command):
+        websocket_max_message_size, aiohttp_no_ssl_connector, aiohttp_request_timeout, command):
     
     # enable_pretty_logging sets StreamHandler and Formatter for the specified loggers so that Jhsingle-native-proxy logs are formatted, sent to sys.stderr, and then outputted in the console. 
     print("Setting pretty logging")
@@ -193,7 +196,7 @@ def run(port, destport, ip, presentation_path, debug, logs, authtype, request_ti
 
     app = make_app(destport, prefix, list(command), presentation_path, authtype, request_timeout, ready_check_path, 
         ready_timeout, repo, repobranch, repofolder, conda_env, debug, logs, forward_user_info, query_user_info, 
-        progressive, websocket_max_message_size)
+        progressive, websocket_max_message_size, aiohttp_no_ssl_connector, aiohttp_request_timeout)
 
     ssl_options = get_ssl_options()
 


### PR DESCRIPTION
This PR:
- Adds additional click options to jhsingle-native-proxy, `--aiohttp-no-ssl-connector` and `--aiohttp-request-timeout`, to configure the aiohttp.ClientSession()
     - `--aiohttp-no-ssl-connector` - including this option passes a TCP connector to aiohttp.ClientSession() that disables SSL verification. If not included defaults to None. 
     - `--aiohttp-request-timeout` - allows you to set the maximal number of seconds for the whole request operation including connection establishment, request sending and response reading. Timeout settings for aiohttp are stored in ClientTimeout data structure. Set to 0 to disable and default is 300 as per the aiohttp.ClientTimeout() documentation. 
     
   - Both options are utilized in the _http_ready_func() in proxyhandlers.py and aid in launching Sequin app. 